### PR TITLE
display-total-and-quantity-number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# intelliJ
+.idea/

--- a/components/CartItem.js
+++ b/components/CartItem.js
@@ -15,7 +15,7 @@ export default function CartItem({ item }) {
       <div>
         {name} <span className="text-xs">({quantity})</span>
       </div>
-      <div className="ml-auto">{price}</div>
+      <div className="ml-auto">￥{price}</div>
       <button
         onClick={() => removeItemFromCart()}
         className="hover:bg-emerald-50 transition-colors rounded-full duration-500 p-1">

--- a/components/ShoppingCart.js
+++ b/components/ShoppingCart.js
@@ -4,6 +4,17 @@ import CheckoutButton from "./CheckoutButton";
 
 export default function ShoppingCart() {
   const { shouldDisplayCart, cartCount, cartDetails } = useShoppingCart();
+
+    const totalPrice = Object.values(cartDetails ?? {}).reduce(
+    (total, item) => total + item.price * item.quantity,
+    0
+    );
+
+    const totalQuantity = Object.values(cartDetails ?? {}).reduce(
+    (total, item) => total + item.quantity,
+    0
+    );
+
   return (
     <div
       className={`bg-white flex flex-col absolute right-3 md:right-9 top-14 w-80 py-4 px-4 shadow-[0_5px_15px_0_rgba(0,0,0,.15)] rounded-md transition-opacity duration-500 ${
@@ -15,6 +26,8 @@ export default function ShoppingCart() {
           {Object.values(cartDetails ?? {}).map((entry) => (
             <CartItem key={entry.id} item={entry} />
           ))}
+          <hr className="my-4 border-gray-300" />
+          <div className="text-right font-bold text-xl md:text-2xl">Total: ￥{totalPrice}({totalQuantity})</div>
           <CheckoutButton />
         </>
       ) : (


### PR DESCRIPTION
add these updates
- Item prices are now shown in Japanese yen
- The cart displays each selected item’s price as well as the total amount

![スクリーンショット 2025-07-02 21 57 42](https://github.com/user-attachments/assets/c6b600bd-3942-4ad5-ab73-7072e0729785)

